### PR TITLE
Implement ProjectsService and move Core services (Teams, Favourites) to a separate DevOpsClient type

### DIFF
--- a/azuredevops/azuredevops.go
+++ b/azuredevops/azuredevops.go
@@ -52,8 +52,8 @@ type ProjectClient struct {
 	WorkItems        *WorkItemsService
 }
 
-// NewClient gets a new Project Client for Azure DevOps API
-func NewClient(account string, project string, token string) *ProjectClient {
+// NewProjectClient gets a new Project Client for Azure DevOps API
+func NewProjectClient(account string, project string, token string) *ProjectClient {
 	devOpsClient := NewDevOpsClient(account, token)
 
 	return devOpsClient.NewProjectClient(project)

--- a/azuredevops/azuredevops_test.go
+++ b/azuredevops/azuredevops_test.go
@@ -23,7 +23,7 @@ func setup() (client *azuredevops.ProjectClient, mux *http.ServeMux, serverURL s
 	devOpsClient, mux, serverURL, teardown := setupDevOpsClient()
 
 	client = devOpsClient.NewProjectClient("AZURE_DEVOPS_Project")
-	
+
 	return client, mux, serverURL, teardown
 }
 
@@ -80,7 +80,7 @@ func testURL(t *testing.T, r *http.Request, want string) {
 
 func Test_NewClient(t *testing.T) {
 	devOpsClient := azuredevops.NewDevOpsClient("AZURE_DEVOPS_ACCOUNT", "AZURE_DEVOPS_TOKEN")
-	
+
 	if devOpsClient.Account != "AZURE_DEVOPS_ACCOUNT" {
 		t.Errorf("Client.Account = %s; expected %s", devOpsClient.Account, "AZURE_DEVOPS_ACCOUNT")
 	}
@@ -94,6 +94,4 @@ func Test_NewClient(t *testing.T) {
 	if projectClient.Project != "AZURE_DEVOPS_Project" {
 		t.Errorf("Client.Project = %s; expected %s", projectClient.Project, "AZURE_DEVOPS_Project")
 	}
-
-	
 }

--- a/azuredevops/azuredevops_test.go
+++ b/azuredevops/azuredevops_test.go
@@ -19,7 +19,15 @@ const (
 )
 
 // Pulled from https://github.com/google/go-github/blob/master/github/github_test.go
-func setup() (client *azuredevops.Client, mux *http.ServeMux, serverURL string, teardown func()) {
+func setup() (client *azuredevops.ProjectClient, mux *http.ServeMux, serverURL string, teardown func()) {
+	devOpsClient, mux, serverURL, teardown := setupDevOpsClient()
+
+	client = devOpsClient.NewProjectClient("AZURE_DEVOPS_Project")
+	
+	return client, mux, serverURL, teardown
+}
+
+func setupDevOpsClient() (client *azuredevops.DevOpsClient, mux *http.ServeMux, serverURL string, teardown func()) {
 	// mux is the HTTP request multiplexer used with the test server.
 	mux = http.NewServeMux()
 
@@ -41,7 +49,7 @@ func setup() (client *azuredevops.Client, mux *http.ServeMux, serverURL string, 
 	server := httptest.NewServer(apiHandler)
 
 	// The client being tested and is configured to use test server.
-	client = azuredevops.NewClient("AZURE_DEVOPS_Account", "AZURE_DEVOPS_Project", "AZURE_DEVOPS_TOKEN")
+	client = azuredevops.NewDevOpsClient("AZURE_DEVOPS_Account", "AZURE_DEVOPS_TOKEN")
 
 	url, _ := url.Parse(server.URL + baseURLPath)
 	client.BaseURL = url.String()
@@ -71,17 +79,21 @@ func testURL(t *testing.T, r *http.Request, want string) {
 }
 
 func Test_NewClient(t *testing.T) {
-	c := azuredevops.NewClient("AZURE_DEVOPS_ACCOUNT", "AZURE_DEVOPS_Project", "AZURE_DEVOPS_TOKEN")
-
-	if c.Account != "AZURE_DEVOPS_ACCOUNT" {
-		t.Errorf("Client.Account = %s; expected %s", c.Account, "AZURE_DEVOPS_ACCOUNT")
+	devOpsClient := azuredevops.NewDevOpsClient("AZURE_DEVOPS_ACCOUNT", "AZURE_DEVOPS_TOKEN")
+	
+	if devOpsClient.Account != "AZURE_DEVOPS_ACCOUNT" {
+		t.Errorf("Client.Account = %s; expected %s", devOpsClient.Account, "AZURE_DEVOPS_ACCOUNT")
 	}
 
-	if c.Project != "AZURE_DEVOPS_Project" {
-		t.Errorf("Client.Project = %s; expected %s", c.Project, "AZURE_DEVOPS_Project")
+	if devOpsClient.AuthToken != "AZURE_DEVOPS_TOKEN" {
+		t.Errorf("Client.Token = %s; expected %s", devOpsClient.AuthToken, "AZURE_DEVOPS_TOKEN")
 	}
 
-	if c.AuthToken != "AZURE_DEVOPS_TOKEN" {
-		t.Errorf("Client.Token = %s; expected %s", c.AuthToken, "AZURE_DEVOPS_TOKEN")
+	projectClient := devOpsClient.NewProjectClient("AZURE_DEVOPS_Project")
+
+	if projectClient.Project != "AZURE_DEVOPS_Project" {
+		t.Errorf("Client.Project = %s; expected %s", projectClient.Project, "AZURE_DEVOPS_Project")
 	}
+
+	
 }

--- a/azuredevops/boards.go
+++ b/azuredevops/boards.go
@@ -8,11 +8,11 @@ import (
 // BoardsService handles communication with the boards methods on the API
 // utilising https://docs.microsoft.com/en-gb/rest/api/vsts/work/boards
 type BoardsService struct {
-	client *Client
+	client *ProjectClient
 }
 
-// ListBoardsResponse describes the boards response
-type ListBoardsResponse struct {
+// BoardsListResponse describes the boards response
+type BoardsListResponse struct {
 	Boards []Board `json:"value"`
 }
 
@@ -41,7 +41,7 @@ func (s *BoardsService) List(team string) ([]Board, error) {
 	if err != nil {
 		return nil, err
 	}
-	var response ListBoardsResponse
+	var response BoardsListResponse
 	_, err = s.client.Execute(request, &response)
 
 	return response.Boards, err

--- a/azuredevops/build_definitions.go
+++ b/azuredevops/build_definitions.go
@@ -16,8 +16,8 @@ type BuildDefinitionsListResponse struct {
 	Count            int               `json:"count"`
 }
 
-// Repository represents a repository used by a build definition
-type Repository struct {
+// BuildRepository represents a repository used by a build definition
+type BuildRepository struct {
 	ID                 string                 `json:"id,omitempty"`
 	Type               string                 `json:"type,omitempty"`
 	Name               string                 `json:"name,omitempty"`
@@ -31,9 +31,9 @@ type Repository struct {
 
 // BuildDefinition represents a build definition
 type BuildDefinition struct {
-	ID         int         `json:"id"`
-	Name       string      `json:"name"`
-	Repository *Repository `json:"repository,omitempty"`
+	ID         int              `json:"id"`
+	Name       string           `json:"name"`
+	Repository *BuildRepository `json:"repository,omitempty"`
 }
 
 // BuildDefinitionsListOptions describes what the request to the API should look like

--- a/azuredevops/build_definitions.go
+++ b/azuredevops/build_definitions.go
@@ -7,7 +7,7 @@ import (
 // BuildDefinitionsService handles communication with the build definitions methods on the API
 // utilising https://docs.microsoft.com/en-gb/rest/api/vsts/build/definitions
 type BuildDefinitionsService struct {
-	client *Client
+	client *ProjectClient
 }
 
 // BuildDefinitionsListResponse describes the build definitions list response

--- a/azuredevops/builds.go
+++ b/azuredevops/builds.go
@@ -7,7 +7,7 @@ import (
 // BuildsService handles communication with the builds methods on the API
 // utilising https://docs.microsoft.com/en-gb/rest/api/vsts/build/builds
 type BuildsService struct {
-	client *Client
+	client *ProjectClient
 }
 
 // BuildsListResponse is the wrapper around the main response for the List of Builds

--- a/azuredevops/delivery_plans.go
+++ b/azuredevops/delivery_plans.go
@@ -8,7 +8,7 @@ import (
 // DeliveryPlansService handles communication with the deliverytimeline methods on the API
 // utilising https://docs.microsoft.com/en-us/rest/api/vsts/work/deliverytimeline
 type DeliveryPlansService struct {
-	client *Client
+	client *ProjectClient
 }
 
 // DeliveryPlansListResponse describes the delivery plans list response

--- a/azuredevops/favourites.go
+++ b/azuredevops/favourites.go
@@ -7,7 +7,7 @@ import (
 // FavouritesService handles communication with the favourites methods on the API
 // So far it looks like this is undocumented, so this could change
 type FavouritesService struct {
-	client *Client
+	client *DevOpsClient
 }
 
 // FavouritesResponse describes the favourites response
@@ -31,7 +31,7 @@ func (s *FavouritesService) List() ([]Favourite, int, error) {
 		"Microsoft.TeamFoundation.Git.Repository", // @todo This needs fixing
 	)
 
-	request, err := s.client.NewBaseRequest("GET", URL, nil)
+	request, err := s.client.NewRequest("GET", URL, nil)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/azuredevops/favourites_test.go
+++ b/azuredevops/favourites_test.go
@@ -43,7 +43,7 @@ func TestFavouritesService_List(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			c, mux, _, teardown := setup()
+			c, mux, _, teardown := setupDevOpsClient()
 			defer teardown()
 
 			mux.HandleFunc(tc.URL, func(w http.ResponseWriter, r *http.Request) {

--- a/azuredevops/git.go
+++ b/azuredevops/git.go
@@ -11,6 +11,24 @@ type GitService struct {
 	client *ProjectClient
 }
 
+// RepositoriesListResponse describes git list response
+type RepositoriesListResponse struct {
+	Repositories []Repository `json:"value"`
+	Count        int          `json:"count,omitempty"`
+}
+
+// Repository describes a git repository
+type Repository struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	URL           string `json:"url"`
+	DefaultBranch string `json:"defaultBranch"`
+	Size          int    `json:"size"`
+	RemoteURL     string `json:"remoteUrl"`
+	SSHURL        string `json:"sshUrl"`
+	WebURL        string `json:"webUrl"`
+}
+
 // GitListRefsResponse describes the git refs list response
 type GitListRefsResponse struct {
 	Count int   `json:"count"`
@@ -47,6 +65,19 @@ type GitRefListOptions struct {
 	Filter             string `url:"filter,omitempty"`
 	IncludeStatuses    bool   `url:"includeStatuses,omitempty"`
 	LatestStatusesOnly bool   `url:"latestStatusesOnly,omitempty"`
+}
+
+func (s *GitService) List() ([]Repository, error) {
+	URL := "/_apis/git/repositories?api-version=5.0"
+
+	request, err := s.client.NewRequest("GET", URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	var response RepositoriesListResponse
+	_, err = s.client.Execute(request, &response)
+
+	return response.Repositories, err
 }
 
 // ListRefs returns a list of the references for a git repo

--- a/azuredevops/git.go
+++ b/azuredevops/git.go
@@ -8,7 +8,7 @@ import (
 // GitService handles communication with the git methods on the API
 // See: https://docs.microsoft.com/en-us/rest/api/vsts/git/
 type GitService struct {
-	client *Client
+	client *ProjectClient
 }
 
 // GitListRefsResponse describes the git refs list response

--- a/azuredevops/git.go
+++ b/azuredevops/git.go
@@ -67,6 +67,7 @@ type GitRefListOptions struct {
 	LatestStatusesOnly bool   `url:"latestStatusesOnly,omitempty"`
 }
 
+// List returns a list of the repositories
 func (s *GitService) List() ([]Repository, error) {
 	URL := "/_apis/git/repositories?api-version=5.0"
 

--- a/azuredevops/iterations.go
+++ b/azuredevops/iterations.go
@@ -8,7 +8,7 @@ import (
 // IterationsService handles communication with the work items methods on the API
 // utilising https://docs.microsoft.com/en-gb/rest/api/vsts/work/iterations
 type IterationsService struct {
-	client *Client
+	client *ProjectClient
 }
 
 // IterationsResponse describes the iterations response

--- a/azuredevops/projects.go
+++ b/azuredevops/projects.go
@@ -19,12 +19,10 @@ type Project struct {
 	Description    string `json:"description"`
 	URL            string `json:"url"`
 	State          string `json:"state"`
-	Revision       int `json:"revision"`
+	Revision       int    `json:"revision"`
 	Visibility     string `json:"visibility"`
 	LastUpdateTime string `json:"lastUpdateTime"`
 }
-
-const projectsBaseURL = "_apis/projects?"
 
 // List returns a list of the projects
 func (s *ProjectsService) List() ([]Project, error) {

--- a/azuredevops/projects.go
+++ b/azuredevops/projects.go
@@ -1,0 +1,41 @@
+package azuredevops
+
+// ProjectsService handles communication with the project methods on the API
+// utilising https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects
+type ProjectsService struct {
+	client *DevOpsClient
+}
+
+// ProjectsListResponse describes what the list API call returns for Projects
+type ProjectsListResponse struct {
+	Projects []Project `json:"value"`
+	Count    int       `json:"count,omitempty"`
+}
+
+// Project describes a project
+type Project struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	URL            string `json:"url"`
+	State          string `json:"state"`
+	Revision       int `json:"revision"`
+	Visibility     string `json:"visibility"`
+	LastUpdateTime string `json:"lastUpdateTime"`
+}
+
+const projectsBaseURL = "_apis/projects?"
+
+// List returns a list of the projects
+func (s *ProjectsService) List() ([]Project, error) {
+	URL := "/_apis/projects?api-version=5.0"
+
+	request, err := s.client.NewRequest("GET", URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	var response ProjectsListResponse
+	_, err = s.client.Execute(request, &response)
+
+	return response.Projects, err
+}

--- a/azuredevops/projects_test.go
+++ b/azuredevops/projects_test.go
@@ -1,0 +1,106 @@
+package azuredevops_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+const (
+	projectListURL      = "/_apis/projects"
+	projectListResponse = `{
+		"count": 3,
+		"value": [
+			{
+				"id": "00000000-0000-0000-0000-000000000001",
+				"name": "Project 1",
+				"description": "Project Description 1",
+				"url": "https://dev.azure.com/AZURE_DEVOPS_Account/_apis/projects/00000000-0000-0000-0000-000000000001",
+				"state": "wellFormed",
+				"revision": 1,
+				"visibility": "private",
+				"lastUpdateTime": "2019-01-01T01:23:45.678Z"
+			},
+			{
+				"id": "00000000-0000-0000-0000-000000000002",
+				"name": "Project 2",
+				"description": "Project Description 2",
+				"url": "https://dev.azure.com/AZURE_DEVOPS_Account/_apis/projects/00000000-0000-0000-0000-000000000002",
+				"state": "wellFormed",
+				"revision": 2,
+				"visibility": "private",
+				"lastUpdateTime": "2019-01-02T01:23:45.678Z"
+			},
+			{
+				"id": "00000000-0000-0000-0000-000000000003",
+				"name": "Project 3",
+				"description": "Project Description 2",
+				"url": "https://dev.azure.com/AZURE_DEVOPS_Account/_apis/projects/00000000-0000-0000-0000-000000000003",
+				"state": "wellFormed",
+				"revision": 3,
+				"visibility": "private",
+				"lastUpdateTime": "2019-01-03T01:23:45.678Z"
+			}
+		]
+	}`
+)
+
+func TestProjectsService_List(t *testing.T) {
+	tt := []struct {
+		name           string
+		URL            string
+		response       string
+		count          int
+		index          int
+		projectName    string
+		result         string
+		definitionName string
+	}{
+		{name: "return two boards", URL: projectListURL, response: projectListResponse, count: 3, index: 0, projectName: "Project 1"},
+		{name: "can handle no projects returned", URL: projectListURL, response: "{}", count: 0, index: -1},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			c, mux, _, teardown := setupDevOpsClient()
+			defer teardown()
+
+			mux.HandleFunc(tc.URL, func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				json := tc.response
+				fmt.Fprint(w, json)
+			})
+
+			projects, err := c.Projects.List()
+			if err != nil {
+				t.Fatalf("returned error: %v", err)
+			}
+
+			if tc.index > -1 {
+				if projects[tc.index].Name != tc.projectName {
+					t.Fatalf("expected board name: %s, got %s", tc.projectName, projects[tc.index].Name)
+				}
+			}
+
+			if len(projects) != tc.count {
+				t.Fatalf("expected length of builds to be %d; got %d", tc.count, len(projects))
+			}
+		})
+	}
+}
+
+func TestProjectsService_List_ResponseDecodeFailure(t *testing.T) {
+	c, mux, _, teardown := setupDevOpsClient()
+	defer teardown()
+
+	mux.HandleFunc(boardListURL, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		json := "sad"
+		fmt.Fprint(w, json)
+	})
+
+	_, err := c.Projects.List()
+	if err == nil {
+		t.Fatalf("expected error decoding the response, did not get one")
+	}
+}

--- a/azuredevops/pull_requests.go
+++ b/azuredevops/pull_requests.go
@@ -5,7 +5,7 @@ import "fmt"
 // PullRequestsService handles communication with the pull requests methods on the API
 // utilising https://docs.microsoft.com/en-us/rest/api/vsts/git/pull%20requests
 type PullRequestsService struct {
-	client *Client
+	client *ProjectClient
 }
 
 // PullRequestsResponse describes the pull requests response

--- a/azuredevops/teams.go
+++ b/azuredevops/teams.go
@@ -3,9 +3,9 @@ package azuredevops
 import "fmt"
 
 // TeamsService handles communication with the teams methods on the API
-// utilising https://docs.microsoft.com/en-us/rest/api/vsts/core/teams/get%20all%20teams
+// utilising https://docs.microsoft.com/ru-ru/rest/api/azure/devops/core/Teams
 type TeamsService struct {
-	client *Client
+	client *DevOpsClient
 }
 
 // TeamsListResponse describes what the list API call returns for teams
@@ -34,7 +34,7 @@ func (s *TeamsService) List(opts *TeamsListOptions) ([]Team, int, error) {
 	URL := fmt.Sprintf("/_apis/teams?api-version=4.1")
 	URL, err := addOptions(URL, opts)
 
-	request, err := s.client.NewBaseRequest("GET", URL, nil)
+	request, err := s.client.NewRequest("GET", URL, nil)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/azuredevops/teams_test.go
+++ b/azuredevops/teams_test.go
@@ -45,7 +45,7 @@ func TestTeamsService_List(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			c, mux, _, teardown := setup()
+			c, mux, _, teardown := setupDevOpsClient()
 			defer teardown()
 
 			mux.HandleFunc(tc.URL, func(w http.ResponseWriter, r *http.Request) {

--- a/azuredevops/tests.go
+++ b/azuredevops/tests.go
@@ -8,7 +8,7 @@ import (
 // TestsService handles communication with the Tests methods on the API
 // utilising https://docs.microsoft.com/en-gb/rest/api/vsts/test
 type TestsService struct {
-	client *Client
+	client *ProjectClient
 }
 
 // TestListResponse is the wrapper around the main response for the List of Tests

--- a/azuredevops/work_items.go
+++ b/azuredevops/work_items.go
@@ -10,7 +10,7 @@ import (
 // WorkItemsService handles communication with the work items methods on the API
 // utilising https://docs.microsoft.com/en-gb/rest/api/vsts/wit/work%20items
 type WorkItemsService struct {
-	client *Client
+	client *ProjectClient
 }
 
 // WorkItemsResponse describes the relationships between work items

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,3 @@
 github.com/benmatselby/go-azuredevops v0.0.0-20190112144040-c2a0219308ca/go.mod h1:1iGYUo0OwirKk+wm+lftDoaTtOgRYRuIZ81Fq1IJZTw=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=


### PR DESCRIPTION
Hi @benmatselby,

This pull request describes what I meant by the issue #30.

I implemented a new 'DevOpsClient' type which contains services which relate to entire DevOps account and not to the project - Favourites, Projects, Teams. These APIs described in the 'Core' section of the documentation: https://docs.microsoft.com/ru-ru/rest/api/azure/devops/core/

I also renamed 'Client' type to 'ProjectClient' as all its services are about just one project.

I didn't remove NewClient(account, project, token) function for backward compatibility, but it also could be initialized something like this:

```go
client := azuredevops.NewDevOpsClient(account, token)
projectClient := client.NewProjectClient(project)
```

Looking forward to your feedback!

Thank you!